### PR TITLE
Updated Script to include ranks

### DIFF
--- a/completionist.py
+++ b/completionist.py
@@ -1,13 +1,14 @@
 import requests
 from pprint import pprint
-from sty import fg, ef, rs
+from sty import fg, ef
 
 
 def getInfo(call):
     r = requests.get(call)
     return r.json()
 
-isUUID = True
+
+isUUID = False
 name = "ShamanOnly"
 uuid = "c8db30d3-b1b0-49d7-9b60-1b29a782b4fd"
 fiveCompletions = False
@@ -15,48 +16,70 @@ fiveCompletions = False
 url = f"https://api.wynncraft.com/v2/player/{uuid if isUUID else name}/stats"
 resp = getInfo(url)
 
-def color_percentage(value):
 
-    if(value >= 1):
-        return ( ef.bold + fg(0, 255, 0) + f" {value:>7.3%} " + fg.rs + ef.rs)
-    
-    if(value <= 0):
-        return ( ef.bold + fg(255, 0, 0) + f" {value:>7.3%} " + fg.rs + ef.rs)
+def color_percentage(color_value):
+    if color_value >= 1:
+        return ef.bold + fg(0, 255, 0) + f" {color_value:>7.3%} " + fg.rs + ef.rs
 
-    green_value = min( round(value * 510) , 255)
-    red_value = min( abs( 510 - round(value * 510) ) , 255)
+    if color_value <= 0:
+        return ef.bold + fg(255, 0, 0) + f" {color_value:>7.3%} " + fg.rs + ef.rs
 
-    return ( fg(red_value, green_value, 0) + f" {f'{value:.3%}'.rjust(7, ' ')} " + fg.rs)
+    green_value = min(round(color_value * 510), 255)
+    red_value = min(abs(510 - round(color_value * 510)), 255)
+
+    return fg(red_value, green_value, 0) + f" {f'{color_value:.3%}'.rjust(7, ' ')} " + fg.rs
 
 
 def show_total_progress(stats):
     # Big ones
-    print(f"""{(ef.bold + 'Total Level' + ef.rs):^61}| {stats['Level']:>7,} / {'23,660':>6}  | { color_percentage( stats['Level'] / 23660 ) }""")
-    print(f"""{(ef.bold + 'Combat' + ef.rs):^61}| {stats['Combat']:>7,} / {'1,484':>6}  | { color_percentage( stats['Combat'] / 1484 ) }""")
+    print(
+        f"{(ef.bold + 'Total Level' + ef.rs):^61}| {stats['Level']:>7,} / {f'{(max_total := 1690 * max_classes)}':>6}  |"
+        f" {color_percentage(stats['Level'] / max_total)}")
+    print(f"{(ef.bold + 'Combat' + ef.rs):^61}| {stats['Combat']:>7,} / {f'{(max_combat := 106 * max_classes)}':>6}  |"
+          f" {color_percentage(stats['Combat'] / max_combat)}")
 
     # Profs
-    for prof in ["Farming", "Fishing", "Mining", "Woodcutting", "Alchemism", "Armouring", "Cooking", "Jeweling", "Scribing", "Tailoring", "Weaponsmithing", "Woodworking"]:
-        print(f"""{(fg(197, 118, 246) + prof + fg.rs):^46}| {stats[prof]:>7,} / {'1,848':>6}  | { color_percentage( stats[prof] / 1848 ) }""")
+    for prof in ["Farming", "Fishing", "Mining", "Woodcutting", "Alchemism", "Armouring", "Cooking", "Jeweling",
+                 "Scribing", "Tailoring", "Weaponsmithing", "Woodworking"]:
+        print(f"{(fg(197, 118, 246) + prof + fg.rs):^46}| {stats[prof]:>7,} /"
+              f" {f'{(single_prof_level := 132 * max_classes)}':>6}  | {color_percentage(stats[prof] / single_prof_level)}")
 
     # Quests
-    print(f"""{(fg(0, 150, 255) + 'Main Quests' + fg.rs):^44}| {stats['Quests']:>7,} / {'1,890':>6}  | { color_percentage( stats['Quests'] / 1890 ) }""")
-    print(f"""{(fg(0, 150, 255) + 'Slaying Mini-Quests' + fg.rs):^44}| {stats['Slaying Mini-Quests']:>7,} / {'406':>6}  | { color_percentage( stats['Slaying Mini-Quests'] / 406 ) }""")
-    print(f"""{(fg(0, 150, 255) + 'Gathering Mini-Quests' + fg.rs):^44}| {stats['Gathering Mini-Quests']:>7,} / {'1,344':>6}  | { color_percentage( stats['Gathering Mini-Quests'] / 1344 ) }""")
+    print(f"{(fg(0, 150, 255) + 'Main Quests' + fg.rs):^44}| {stats['Quests']:>7,} /"
+          f" {f'{(total_quests := 135 * max_classes)}':>6}  |"
+          f" {color_percentage(stats['Quests'] / total_quests)}")
+    print(f"{(fg(0, 150, 255) + 'Slaying Mini-Quests' + fg.rs):^44}|"
+          f" {stats['Slaying Mini-Quests']:>7,} / {f'{(total_slaying := max_classes * 29)}':>6}  |"
+          f" {color_percentage(stats['Slaying Mini-Quests'] / total_slaying)}")
+    print(f"{(fg(0, 150, 255) + 'Gathering Mini-Quests' + fg.rs):^44}|"
+          f" {stats['Gathering Mini-Quests']:>7,} / {f'{(total_gathering := 96 * max_classes)}':>6}  |"
+          f" {color_percentage(stats['Gathering Mini-Quests'] / total_gathering)}")
 
     # Completionist
-    print(f"""{(fg(46, 204, 113) + 'Discoveries' + fg.rs):^45}| {stats['Discoveries']:>7,} / {'8,320':>6}  | { color_percentage( stats['Discoveries'] / 8320 ) }""")
-    print(f"""{(fg(46, 204, 113) + 'Unique Dungeons' + fg.rs):^45}| {stats['Unique Dungeon Completions']:>7,} / {'238':>6}  | { color_percentage( stats['Unique Dungeon Completions'] / 238 ) }""")
-    if(fiveCompletions):
-        print(f"""{(fg(46, 204, 113) + 'Dungeon Completions' + fg.rs):^45}| {stats['Dungeon Completions']:>7,} / {'1,190':>6}  | { color_percentage( stats['Dungeon Completions'] / 1190 ) }""")
-    print(f"""{(fg(46, 204, 113) + 'Unique Raids' + fg.rs):^45}| {stats['Unique Raid Completions']:>7,} / {'42':>6}  | { color_percentage( stats['Unique Raid Completions'] / 42 ) }""")
-    if(fiveCompletions):
-        print(f"""{(fg(46, 204, 113) + 'Raid Completions' + fg.rs):^45}| {stats['Raid Completions']:>7,} / {'210':>6}  | { color_percentage( stats['Raid Completions'] / 210 ) }""")
-    
+    print(f"{(fg(46, 204, 113) + 'Discoveries' + fg.rs):^45}|"
+          f" {stats['Discoveries']:>7,} / {f'{(total_discoveries := (249 + 406) * max_classes)}':>6}  |"
+          f" {color_percentage(stats['Discoveries'] / total_discoveries)}")
+    print(f"{(fg(46, 204, 113) + 'Unique Dungeons' + fg.rs):^45}|"
+          f" {stats['Unique Dungeon Completions']:>7,} / {f'{(total_dungeons := max_classes * 17)}':>6}  |"
+          f" {color_percentage(stats['Unique Dungeon Completions'] / total_dungeons)}")
+    if fiveCompletions:
+        print(f"{(fg(46, 204, 113) + 'Dungeon Completions' + fg.rs):^45}|"
+              f" {stats['Dungeon Completions']:>7,} / {'1,190':>6}  |"
+              f" {color_percentage(stats['Dungeon Completions'] / 1190)}")
+    print(f"{(fg(46, 204, 113) + 'Unique Raids' + fg.rs):^45}|"
+          f" {stats['Unique Raid Completions']:>7,} / {f'{(total_raids := 3 * max_classes)}':>6}  |"
+          f" {color_percentage(stats['Unique Raid Completions'] / total_raids)}")
+    if fiveCompletions:
+        print(f"{(fg(46, 204, 113) + 'Raid Completions' + fg.rs):^45}|"
+              f" {stats['Raid Completions']:>7,} / {'210':>6}  | {color_percentage(stats['Raid Completions'] / 210)}")
+
 
 classes = resp["data"][0]["classes"]
+rank = resp["data"][0]['meta']['tag']['value']
+max_classes = {None: 6, "VIP": 9, "VIP+": 11, "HERO": 14, "CHAMPION": 14}[rank]
 shamans = []
 account_total = {
-    "Level": 0 ,
+    "Level": 0,
     "Combat": 0,
     "Farming": 0,
     "Fishing": 0,
@@ -79,34 +102,30 @@ account_total = {
     "Unique Raid Completions": 0,
     "Raid Completions": 0
 }
-class_totals = {
-
-}
+class_totals = {}
 
 for wynn_class in classes:
 
     # Class link
-    cur_class = [
-        wynn_class["name"],
-        wynn_class["professions"]["combat"]["level"] + wynn_class["professions"]["combat"]["xp"] / 100
-    ]
+    cur_class = [wynn_class["name"],
+                 wynn_class["professions"]["combat"]["level"] + wynn_class["professions"]["combat"]["xp"] / 100]
 
     # Quest sorting
     content_quests = 0
     slaying_quests = 0
     prof_quests = 0
     for quest in wynn_class["quests"]["list"]:
-        if("Mini-Quest - Gather" in quest):
+        if "Mini-Quest - Gather" in quest:
             prof_quests += 1
-        elif("Mini-Quest" in quest):
+        elif "Mini-Quest" in quest:
             slaying_quests += 1
         else:
             content_quests += 1
-    
+
     dungeons_completed = 0
     for dungeon in wynn_class["dungeons"]["list"]:
         dungeons_completed += min(dungeon["completed"], 5)
-    
+
     raids_completed = 0
     for raid in wynn_class["raids"]["list"]:
         raids_completed += min(raid["completed"], 5)
@@ -142,9 +161,9 @@ for wynn_class in classes:
         account_total[key] = value + class_totals[wynn_class["name"]][key]
 
     # Append to account list
-    shamans.append( tuple(cur_class) )
+    shamans.append(tuple(cur_class))
 
-shamans.sort(key = lambda x: -x[1])
+shamans.sort(key=lambda x: -x[1])
 
 # Shows order of your classes id sorted by combat xp 
 # pprint(shamans)


### PR DESCRIPTION
Stats are now calculated depending on the rank a player has.
New:
- The script dertermines if a player has
- All stats get calculated by the players rank so players with no ranks/lower ranks get higher completion scores.
- Formated code confirm to PEP8 https://peps.python.org/pep-0008/
I tested the code with multiple players of each rank
Note: the Script assumes that there are 249 Discoveries (World+Secret) + 406 Territories. This may be inaccurate and could be improved.
